### PR TITLE
pass options to marked

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,15 @@ This returns:
 
 ## Passing options to [marked](https://github.com/chjj/marked)
 
-Use YAML at the top of the markdown string to pass options to marked.
-
 ```js
 var md = require('beldown')
 
-var html = md`---
+md.setOptions({
   gfm: false
-  ---
+})
 
-  ~~Github flavored markdown is off~~
-`
+var html = md`~~Github flavored markdown is off~~`
+console.log(html.toString())
 ```
 
 This returns:
@@ -55,25 +53,6 @@ This returns:
 ```html
 <div>
 <p>~~Github flavorded markdown is off~~</p>
-</div>
-```
-
-To turn gfm back on you would do this:
-
-```js
-var html = md`---
-  gfm: true
-  ---
-
-  ~~Github flavored markdown is back on~~
-`
-```
-
-This returns:
-
-```html
-<div>
-<p><del>Github flavorded markdown is back on</del></p>
 </div>
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This returns:
 
 ```html
 <div>
-<p>~~Github flavorded markdown is off~~</p>
+<p>~~Github flavored markdown is off~~</p>
 </div>
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,52 @@ This returns:
 </div>
 ```
 
+## Passing options to [marked](https://github.com/chjj/marked)
+
+Use YAML at the top of the markdown string to pass options to marked.
+
+```js
+var md = require('beldown')
+
+var html = md`---
+  gfm: false
+  ---
+
+  ~~Github flavored markdown is off~~
+`
+```
+
+This returns:
+
+```html
+<div>
+<p>~~Github flavorded markdown is off~~</p>
+</div>
+```
+
+To turn gfm back on you would do this:
+
+```js
+var html = md`---
+  gfm: true
+  ---
+
+  ~~Github flavored markdown is back on~~
+`
+```
+
+This returns:
+
+```html
+<div>
+<p><del>Github flavorded markdown is back on</del></p>
+</div>
+```
+
 ## Caveats:
 The wrapping div is required because multiple root elements must be wrapped in an enclosing tag. I'm not sure if there's a great way around that.
 
 Leading whitespace of each line is currently stripped. Maybe there's a case where that breaks things?
-
-There's not yet a way to pass options to marked. That would be nice.
 
 ## License
 [ISC](LICENSE.md)

--- a/example.js
+++ b/example.js
@@ -8,11 +8,12 @@ var html = md`
 
 console.log(html.toString())
 
-var options = md`---
+// set marked options
+
+md.setOptions({
   gfm: false
-  ---
-  
-  ~~Github flavorded markdown is off~~
-`
+})
+
+var options = md`~~Github flavorded markdown is off~~`
 
 console.log(options.toString())

--- a/example.js
+++ b/example.js
@@ -14,6 +14,6 @@ md.setOptions({
   gfm: false
 })
 
-var options = md`~~Github flavorded markdown is off~~`
+var options = md`~~Github flavored markdown is off~~`
 
 console.log(options.toString())

--- a/example.js
+++ b/example.js
@@ -7,3 +7,12 @@ var html = md`
 `
 
 console.log(html.toString())
+
+var options = md`---
+  gfm: false
+  ---
+  
+  ~~Github flavorded markdown is off~~
+`
+
+console.log(options.toString())

--- a/index.js
+++ b/index.js
@@ -1,10 +1,20 @@
 var marked = require('marked')
 var bel = require('bel')
+var fm = require('front-matter')
 
 module.exports = function beldown (strings) {
   var parts = []
   var l = strings.length
   var i = 0
+  
+  // use front-matter to get options for marked
+  if (fm.test(strings[i])) {
+    var content = fm(strings[i])
+    var opts = content.attributes
+    marked.setOptions(opts)
+    strings = [].concat(strings)
+    strings[i] = content.body
+  }
 
   // strip leading whitespace (hopefully this doesn't break anything)
   for (i; i < l; i++) {

--- a/index.js
+++ b/index.js
@@ -1,20 +1,10 @@
 var marked = require('marked')
 var bel = require('bel')
-var fm = require('front-matter')
 
 module.exports = function beldown (strings) {
   var parts = []
   var l = strings.length
   var i = 0
-  
-  // use front-matter to get options for marked
-  if (fm.test(strings[i])) {
-    var content = fm(strings[i])
-    var opts = content.attributes
-    marked.setOptions(opts)
-    strings = [].concat(strings)
-    strings[i] = content.body
-  }
 
   // strip leading whitespace (hopefully this doesn't break anything)
   for (i; i < l; i++) {
@@ -31,3 +21,5 @@ module.exports = function beldown (strings) {
   arguments[0] = parts
   return bel.apply(null, arguments)
 }
+
+module.exports.setOptions = marked.setOptions

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "homepage": "https://github.com/sethvincent/beldown#readme",
   "dependencies": {
     "bel": "^4.4.3",
-    "front-matter": "^2.1.0",
     "marked": "^0.3.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/sethvincent/beldown#readme",
   "dependencies": {
     "bel": "^4.4.3",
+    "front-matter": "^2.1.0",
     "marked": "^0.3.6"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -6,3 +6,23 @@ test('hi', function (t) {
   t.equal(html.toString(), `<div>\n<p>hi</p>\n</div>`)
   t.end()
 })
+
+test('options', function (t) {
+  var gfmOff = md`---
+  gfm: false
+  ---
+  
+  ~~cool~~
+  `
+  
+  var gfmOn = md`---
+  gfm: true
+  ---
+  
+  ~~cool~~
+  `
+  
+  t.equal(gfmOff.toString(), '<div>\n<p>~~cool~~</p>\n</div>')
+  t.equal(gfmOn.toString(), '<div>\n<p><del>cool</del></p>\n</div>')
+  t.end()
+})

--- a/test.js
+++ b/test.js
@@ -8,21 +8,12 @@ test('hi', function (t) {
 })
 
 test('options', function (t) {
-  var gfmOff = md`---
-  gfm: false
-  ---
+  md.setOptions({
+    gfm: false
+  })
   
-  ~~cool~~
-  `
+  var html = md`~~cool~~`
   
-  var gfmOn = md`---
-  gfm: true
-  ---
-  
-  ~~cool~~
-  `
-  
-  t.equal(gfmOff.toString(), '<div>\n<p>~~cool~~</p>\n</div>')
-  t.equal(gfmOn.toString(), '<div>\n<p><del>cool</del></p>\n</div>')
+  t.equal(html.toString(), '<div>\n<p>~~cool~~</p>\n</div>')
   t.end()
 })


### PR DESCRIPTION
Greetings 👋

This commit lets users pass options to marked by writing yaml in the top of their markdown string.
**note:** the three dashes _must_ be at the start of the string to enable option settings.

example for setting the gfm option to false:

``` javascript
var gfmSetFalse = md`---
  gfm: false
  ---

  ~~cool~~
`

console.log(gfmSetFalse.toString()) // `<div>\n<p>~~cool~~</p>\n</div>`
```

example for resetting gfm option back to true:

``` javascript
var gfmSetTrue = md`---
  gfm: true
  ---

  ~~cool~~
`

console.log(gfmSetTrue.toString()) // '<div>\n<p><del>cool</del></p>\n</div>'
```
